### PR TITLE
Platform team rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # cluster-olympus
 Integration Cluster for the club Golang Buddies
+
+## RBAC
+
+### Platform Team
+
+- `platform-team-admin`: user role with admin privileges on the entire cluster.
+- `platform-team`: user role with read-write privileges on the entire cluster.
+- `platform-team-guest`: user role with read-only privileges on the entire cluster.

--- a/rbac/platform-team/read-only-role-binding.yaml
+++ b/rbac/platform-team/read-only-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+ name: platform-team-guest-binding
+roleRef:
+ kind: ClusterRole
+ name: read-only-role
+ apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: User
+ name: platform-team-guest
+ apiGroup: rbac.authorization.k8s.io

--- a/rbac/platform-team/read-write-role-binding.yaml
+++ b/rbac/platform-team/read-write-role-binding.yaml
@@ -4,7 +4,7 @@ metadata:
  name: platform-team-binding
 roleRef:
  kind: ClusterRole
- name: platform-team-role
+ name: read-write-role
  apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: User


### PR DESCRIPTION
# Goal
Create the rbac for the platform team. 
Roles which have been setup:
platform-team-admin, platform-team, platform-team-guest
